### PR TITLE
integration testing: add and validate build-time options for tailscal…

### DIFF
--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -28,7 +28,9 @@ ARG VERSION_GIT_HASH=""
 ENV VERSION_GIT_HASH=$VERSION_GIT_HASH
 ARG TARGETARCH
 
-RUN GOARCH=$TARGETARCH go install -ldflags="\
+ARG BUILD_TAGS=""
+
+RUN GOARCH=$TARGETARCH go install -tags="${BUILD_TAGS}" -ldflags="\
       -X tailscale.com/version.longStamp=$VERSION_LONG \
       -X tailscale.com/version.shortStamp=$VERSION_SHORT \
       -X tailscale.com/version.gitCommitStamp=$VERSION_GIT_HASH" \

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -55,7 +55,7 @@ func TestDERPServerWebsocketScenario(t *testing.T) {
 	spec := map[string]ClientsSpec{
 		"user1": {
 			Plain:         0,
-			WebsocketDERP: len(MustTestVersions),
+			WebsocketDERP: 2,
 		},
 	}
 
@@ -239,10 +239,13 @@ func (s *EmbeddedDERPServerScenario) CreateHeadscaleEnv(
 
 		if clientCount.WebsocketDERP > 0 {
 			// Containers that use DERP-over-WebSocket
+			// Note that these clients *must* be built
+			// from source, which is currently
+			// only done for HEAD.
 			err = s.CreateTailscaleIsolatedNodesInUser(
 				hash,
 				userName,
-				"all",
+				"head",
 				clientCount.WebsocketDERP,
 				tsic.WithWebsocketDERP(true),
 			)

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -245,7 +245,7 @@ func (s *EmbeddedDERPServerScenario) CreateHeadscaleEnv(
 			err = s.CreateTailscaleIsolatedNodesInUser(
 				hash,
 				userName,
-				"head",
+				tsic.VersionHead,
 				clientCount.WebsocketDERP,
 				tsic.WithWebsocketDERP(true),
 			)

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,7 @@ var (
 	errTailscaleCannotUpWithoutAuthkey = errors.New("cannot up without authkey")
 	errTailscaleNotConnected           = errors.New("tailscale not connected")
 	errTailscaledNotReadyForLogin      = errors.New("tailscaled not ready for login")
+	errInvalidClientConfig             = errors.New("verifiably invalid client config requested")
 )
 
 func errTailscaleStatus(hostname string, err error) error {
@@ -74,6 +76,13 @@ type TailscaleInContainer struct {
 	withExtraHosts    []string
 	workdir           string
 	netfilter         string
+
+	// build options, solely for HEAD
+	buildConfig TailscaleInContainerBuildConfig
+}
+
+type TailscaleInContainerBuildConfig struct {
+	tags []string
 }
 
 // Option represent optional settings that can be given to a
@@ -175,6 +184,18 @@ func WithNetfilter(state string) Option {
 	}
 }
 
+// WithBuildTag adds an additional value to the `-tags=` parameter
+// of the Go compiler, allowing callers to customize the Tailscale client build.
+// This option is only meaningful when invoked on **HEAD** versions of the client.
+// Attempts to use it with any other version is a bug in the calling code.
+func WithBuildTag(tag string) Option {
+	return func(tsic *TailscaleInContainer) {
+		tsic.buildConfig.tags = append(
+			tsic.buildConfig.tags, tag,
+		)
+	}
+}
+
 // New returns a new TailscaleInContainer instance.
 func New(
 	pool *dockertest.Pool,
@@ -219,6 +240,12 @@ func New(
 	}
 
 	if tsic.withWebsocketDERP {
+		if version != "head" {
+			return nil, errInvalidClientConfig
+		}
+
+		WithBuildTag("ts_debug_websockets")(tsic)
+
 		tailscaleOptions.Env = append(
 			tailscaleOptions.Env,
 			fmt.Sprintf("TS_DEBUG_DERP_WS_CLIENT=%t", tsic.withWebsocketDERP),
@@ -245,12 +272,34 @@ func New(
 	}
 
 	var container *dockertest.Resource
+
+	if version != "head" {
+		// build options are not meaningful with pre-existing images,
+		// let's not lead anyone astray by pretending otherwise.
+		defaultBuildConfig := TailscaleInContainerBuildConfig{}
+		hasBuildConfig := reflect.DeepEqual(defaultBuildConfig, tsic.buildConfig)
+		if hasBuildConfig {
+			return nil, errInvalidClientConfig
+		}
+	}
+
 	switch version {
 	case "head":
 		buildOptions := &dockertest.BuildOptions{
 			Dockerfile: "Dockerfile.tailscale-HEAD",
 			ContextDir: dockerContextPath,
 			BuildArgs:  []docker.BuildArg{},
+		}
+
+		buildTags := strings.Join(tsic.buildConfig.tags, ",")
+		if len(buildTags) > 0 {
+			buildOptions.BuildArgs = append(
+				buildOptions.BuildArgs,
+				docker.BuildArg{
+					Name:  "BUILD_TAGS",
+					Value: buildTags,
+				},
+			)
 		}
 
 		container, err = pool.BuildAndRunWithBuildOptions(

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -48,6 +48,10 @@ var (
 	errInvalidClientConfig             = errors.New("verifiably invalid client config requested")
 )
 
+const (
+	VersionHead = "head"
+)
+
 func errTailscaleStatus(hostname string, err error) error {
 	return fmt.Errorf("%s failed to fetch tailscale status: %w", hostname, err)
 }
@@ -240,7 +244,7 @@ func New(
 	}
 
 	if tsic.withWebsocketDERP {
-		if version != "head" {
+		if version != VersionHead {
 			return nil, errInvalidClientConfig
 		}
 
@@ -273,7 +277,7 @@ func New(
 
 	var container *dockertest.Resource
 
-	if version != "head" {
+	if version != VersionHead {
 		// build options are not meaningful with pre-existing images,
 		// let's not lead anyone astray by pretending otherwise.
 		defaultBuildConfig := TailscaleInContainerBuildConfig{}
@@ -284,7 +288,7 @@ func New(
 	}
 
 	switch version {
-	case "head":
+	case VersionHead:
 		buildOptions := &dockertest.BuildOptions{
 			Dockerfile: "Dockerfile.tailscale-HEAD",
 			ContextDir: dockerContextPath,

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -281,7 +281,7 @@ func New(
 		// build options are not meaningful with pre-existing images,
 		// let's not lead anyone astray by pretending otherwise.
 		defaultBuildConfig := TailscaleInContainerBuildConfig{}
-		hasBuildConfig := reflect.DeepEqual(defaultBuildConfig, tsic.buildConfig)
+		hasBuildConfig := !reflect.DeepEqual(defaultBuildConfig, tsic.buildConfig)
 		if hasBuildConfig {
 			return tsic, errInvalidClientConfig
 		}

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -245,7 +245,7 @@ func New(
 
 	if tsic.withWebsocketDERP {
 		if version != VersionHead {
-			return nil, errInvalidClientConfig
+			return tsic, errInvalidClientConfig
 		}
 
 		WithBuildTag("ts_debug_websockets")(tsic)
@@ -283,7 +283,7 @@ func New(
 		defaultBuildConfig := TailscaleInContainerBuildConfig{}
 		hasBuildConfig := reflect.DeepEqual(defaultBuildConfig, tsic.buildConfig)
 		if hasBuildConfig {
-			return nil, errInvalidClientConfig
+			return tsic, errInvalidClientConfig
 		}
 	}
 

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -194,6 +194,10 @@ func WithNetfilter(state string) Option {
 // Attempts to use it with any other version is a bug in the calling code.
 func WithBuildTag(tag string) Option {
 	return func(tsic *TailscaleInContainer) {
+		if tsic.version != VersionHead {
+			panic(errInvalidClientConfig)
+		}
+
 		tsic.buildConfig.tags = append(
 			tsic.buildConfig.tags, tag,
 		)


### PR DESCRIPTION
…e head

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
